### PR TITLE
Non versatile routers can handle null parameters.

### DIFF
--- a/Routing/ChainRouter.php
+++ b/Routing/ChainRouter.php
@@ -95,7 +95,10 @@ class ChainRouter extends CmfChainRouter
         }
 
         foreach ($parameters as $parameter) {
-            if (!is_null($parameter) && !is_scalar($parameter) && !($router instanceof VersatileParameterGeneratorInterface)) {
+            if ($parameter !== null
+                && !is_scalar($parameter)
+                && !($router instanceof VersatileParameterGeneratorInterface)
+            ) {
                 return false;
             }
         }

--- a/Routing/ChainRouter.php
+++ b/Routing/ChainRouter.php
@@ -95,7 +95,7 @@ class ChainRouter extends CmfChainRouter
         }
 
         foreach ($parameters as $parameter) {
-            if (!is_scalar($parameter) && !($router instanceof VersatileParameterGeneratorInterface)) {
+            if (!is_null($parameter) && !is_scalar($parameter) && !($router instanceof VersatileParameterGeneratorInterface)) {
                 return false;
             }
         }

--- a/Tests/Unit/Routing/ChainRouterTest.php
+++ b/Tests/Unit/Routing/ChainRouterTest.php
@@ -176,6 +176,20 @@ class ChainRouterTest extends \PHPUnit_Framework_TestCase
             'expectedUrl' => 'url',
         ];
 
+        // Case #8. Null value as a parameter.
+        $chainRouter = new ChainRouter();
+        /** @var RouterInterface|\PHPUnit_Framework_MockObject_MockObject $router */
+        $router = $this->getMockForAbstractClass('Symfony\Component\Routing\RouterInterface');
+        $router->expects($this->once())->method('generate')->willReturn('expected-url');
+        $chainRouter->add($router);
+        $cases[] = [
+            'router' => $chainRouter,
+            'route' => 'route',
+            'parameters' => [null],
+            'absolute' => false,
+            'expectedUrl' => 'expected-url',
+        ];
+
         return $cases;
     }
 


### PR DESCRIPTION
Regular router is capable of generating urls with null params, so no need to skip them.
Closes #43.