### PR TITLE
Allow to configure document classes instead of raw ES type names

### DIFF
--- a/DependencyInjection/Compiler/SeoRoutesPass.php
+++ b/DependencyInjection/Compiler/SeoRoutesPass.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\RouterBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Resolves type names by configured document class.
+ */
+class SeoRoutesPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $collector = $container->get('es.metadata_collector');
+        $seoRoutes = $container->getParameter('ongr_router.seo_routes');
+        $resolvedRoutes = [];
+
+        foreach ($seoRoutes as $document => $controllerAction) {
+            $document = $collector->getDocumentType($document);
+            $resolvedRoutes[$document] = $controllerAction;
+        }
+
+        $definition = $container->getDefinition('ongr_router.elasticsearch_route_provider');
+        $definition->replaceArgument(1, $resolvedRoutes);
+    }
+}

--- a/ONGRRouterBundle.php
+++ b/ONGRRouterBundle.php
@@ -11,7 +11,7 @@
 
 namespace ONGR\RouterBundle;
 
-use ONGR\RouterBundle\DependencyInjection\Compiler\SeoAnalyzerAwarePass;
+use ONGR\RouterBundle\DependencyInjection\Compiler\SeoRoutesPass;
 use ONGR\RouterBundle\DependencyInjection\Compiler\SetRouterPass;
 use Symfony\Cmf\Component\Routing\DependencyInjection\Compiler\RegisterRoutersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -29,6 +29,7 @@ class ONGRRouterBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new SeoRoutesPass());
         $container->addCompilerPass(new SetRouterPass());
         $container->addCompilerPass(new RegisterRoutersPass('ongr_router.chain_router'));
     }

--- a/README.md
+++ b/README.md
@@ -38,16 +38,15 @@ composer require ongr/router-bundle "~1.0"
 Enable Router and Elasticsearch bundles in your AppKernel:
 
 ```php
-<?php
 // app/AppKernel.php
 
 public function registerBundles()
 {
-    $bundles = array(
+    $bundles = [
         // ...
         new ONGR\ElasticsearchBundle\ONGRElasticsearchBundle(),
         new ONGR\RouterBundle\ONGRRouterBundle(),
-    );
+    ];
 }
 
 ```
@@ -61,7 +60,8 @@ Add minimal configuration for Router and Elasticsearch bundles.
 
 ```yaml
 
-#app/config/config.yml
+# app/config/config.yml
+
 ongr_elasticsearch:
     analysis:
         analyzer:
@@ -84,7 +84,7 @@ ongr_elasticsearch:
 ongr_router:
     manager: es.manager.default
     seo_routes:
-        product: AppBundle:Product:document
+        'AppBundle:Product': AppBundle:Product:document
         # ...
 
 ```
@@ -106,20 +106,17 @@ Check [Elasticsearch bundle mappings docs](https://github.com/ongr-io/Elasticsea
 Lets create a `Product` document class. We assume that we have an AppBundle installed.
 
 ```php
-<?php
 // src/AppBundle/Document/Product.php
 
 namespace AppBundle\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ES;
-use ONGR\ElasticsearchBundle\Document\DocumentTrait;
 
 /**
  * @ES\Document()
  */
 class Product
 {
-    use DocumentTrait;
     use SeoAwareTrait; // <- Trait for URL's
 
     /**
@@ -138,7 +135,6 @@ In favor to support friendly URLs, the bundle provides `SeoAwareTrait` with pred
 #### Step 2: Create controller and action for the product page
 
 ```php
-<?php
 // src/AppBundle/Controller/ProductController.php
 
 namespace AppBundle\Controller;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -10,7 +10,9 @@ services:
 
     ongr_router.elasticsearch_route_provider:
         class: ONGR\RouterBundle\Routing\ElasticsearchRouteProvider
-        arguments: ["@es.metadata_collector", %ongr_router.seo_routes%]
+        arguments:
+            - "@es.metadata_collector"
+            - [] # Actual map is set by compiler pass
 
     ongr_router.final_matcher:
         class: Symfony\Cmf\Component\Routing\NestedMatcher\UrlMatcher

--- a/Routing/ElasticsearchRouteProvider.php
+++ b/Routing/ElasticsearchRouteProvider.php
@@ -70,7 +70,7 @@ class ElasticsearchRouteProvider implements RouteProviderInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getRouteCollectionForRequest(Request $request)
     {
@@ -88,7 +88,7 @@ class ElasticsearchRouteProvider implements RouteProviderInterface
         try {
             foreach ($results as $document) {
                 $type = $this->collector->getDocumentType(get_class($document));
-                if (array_key_exists($type, $this->routeMap)) {
+                if (isset($this->routeMap[$type])) {
                     $route = new Route(
                         $document->url,
                         [
@@ -111,7 +111,7 @@ class ElasticsearchRouteProvider implements RouteProviderInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getRouteByName($name)
     {
@@ -119,7 +119,7 @@ class ElasticsearchRouteProvider implements RouteProviderInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getRoutesByNames($names)
     {

--- a/Tests/app/config/config_test.yml
+++ b/Tests/app/config/config_test.yml
@@ -30,4 +30,4 @@ ongr_elasticsearch:
 ongr_router:
     manager: es.manager.default
     seo_routes:
-        product: AppBundle:Test:document
+        'AppBundle:Product': AppBundle:Test:document


### PR DESCRIPTION
Diff:

```diff
     seo_routes:
-        product: AppBundle:Product:document
+        'AppBundle:Product': AppBundle:Product:document
```

This way user does not need to use real Elasticsearch type name.