### PR TITLE
Support for multiple URLs per document

### DIFF
--- a/Routing/ElasticsearchRouteProvider.php
+++ b/Routing/ElasticsearchRouteProvider.php
@@ -96,16 +96,19 @@ class ElasticsearchRouteProvider implements RouteProviderInterface
             foreach ($results as $document) {
                 $type = $this->collector->getDocumentType(get_class($document));
                 if (isset($this->routeMap[$type])) {
-                    $route = new Route(
-                        $document->url,
-                        [
-                            '_controller' => $this->routeMap[$type],
-                            'document' => $document,
-                            'type' => $type,
-                        ]
-                    );
+                    $urls = is_array($document->url) ? array_values($document->url) : [$document->url];
+                    foreach ($urls as $i => $url) {
+                        $route = new Route(
+                            $url,
+                            [
+                                '_controller' => $this->routeMap[$type],
+                                'document' => $document,
+                                'type' => $type,
+                            ]
+                        );
+                        $routeCollection->add('ongr_route_' . $route->getDefault('type') . '_' . $i, $route);
+                    }
 
-                    $routeCollection->add('ongr_route_' . $route->getDefault('type'), $route);
                 } else {
                     throw new RouteNotFoundException(sprintf('Route for type %s% cannot be generated.', $type));
                 }

--- a/Routing/ElasticsearchRouteProvider.php
+++ b/Routing/ElasticsearchRouteProvider.php
@@ -108,7 +108,6 @@ class ElasticsearchRouteProvider implements RouteProviderInterface
                         );
                         $routeCollection->add('ongr_route_' . $route->getDefault('type') . '_' . $i, $route);
                     }
-
                 } else {
                     throw new RouteNotFoundException(sprintf('Route for type %s% cannot be generated.', $type));
                 }


### PR DESCRIPTION
While not great from a SEO perspective, some setup might have multiple URLs per document, e.g. when detail page URLs are formed from category and product slugs, and the product is in multiple categories. Elasticsearch does not differentiate between `string` and `string[]`, but so far the ongr router couldn't handle that.