### PR TITLE
Missing namespace in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Lets create a `Product` document class. We assume that we have an AppBundle inst
 namespace AppBundle\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ES;
+use ONGR\RouterBundle\Document\SeoAwareTrait;
 
 /**
  * @ES\Document()


### PR DESCRIPTION
Added missing `SeoAwareTrait` namespace in readme example.

Closes #82 