### PR TITLE
covered documentUrlGenerator with tests

### DIFF
--- a/Routing/DocumentUrlGenerator.php
+++ b/Routing/DocumentUrlGenerator.php
@@ -130,7 +130,7 @@ class DocumentUrlGenerator extends ProviderBasedGenerator implements VersatileGe
         if ($name instanceof SeoAwareInterface) {
             return 'The route object is fit for parsing to generate() method';
         } else {
-            return $name.' must be an instance of SeoAwareInterface';
+            return 'Given route object must be an instance of SeoAwareInterface';
         }
     }
 }

--- a/Tests/Functional/DocumentUrlGeneratorTest.php
+++ b/Tests/Functional/DocumentUrlGeneratorTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace ONGR\RouterBundle\Tests\Functional;
 
 use ONGR\RouterBundle\Tests\app\fixture\AppBundle\Document\Product;
@@ -59,5 +68,20 @@ class DocumentUrlGeneratorTest extends WebTestCase
         $url = $router->generate('ongr_router.home', ['param' => ['foo', 'bar']]);
 
         $this->assertEquals('/?param%5B0%5D=foo&param%5B1%5D=bar', $url);
+    }
+
+    /**
+     * Tests unsupported document objects
+     *
+     * @expectedException \Symfony\Component\Routing\Exception\RouteNotFoundException
+     */
+    public function testBadDocumentObject()
+    {
+        $document = new \stdClass();
+
+        $client = static::createClient();
+        $router = $client->getContainer()->get('router');
+
+        $router->generate($document);
     }
 }

--- a/Tests/Functional/ElasticsearchRouterTest.php
+++ b/Tests/Functional/ElasticsearchRouterTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace ONGR\RouterBundle\Tests\Functional;
 
 use ONGR\ElasticsearchBundle\Test\AbstractElasticsearchTestCase;

--- a/Tests/Unit/Routing/DocumentUrlGeneratorTest.php
+++ b/Tests/Unit/Routing/DocumentUrlGeneratorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\RouterBundle\Tests\Unit\Routing;
+
+use ONGR\RouterBundle\Routing\DocumentUrlGenerator;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class DocumentUrlGeneratorTest extends WebTestCase
+{
+    /**
+     * Tests getters and setters
+     */
+    public function testGettersAndSetters()
+    {
+        $routeMap = new \stdClass();
+        $routeProvider = $this->getMock('Symfony\Cmf\Component\Routing\RouteProviderInterface');
+        $collector = $this->getMockBuilder('ONGR\ElasticsearchBundle\Mapping\MetadataCollector')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $urlGenerator = new DocumentUrlGenerator($routeProvider);
+
+        $urlGenerator->setRouteMap($routeMap);
+        $retrievedRoute = $urlGenerator->getRouteMap();
+        $urlGenerator->setCollector($collector);
+        $retrievedCollector = $urlGenerator->getCollector();
+
+        $this->assertEquals($retrievedRoute, $routeMap);
+        $this->assertEquals($retrievedCollector, $collector);
+    }
+
+    /**
+     * Tests debug message when given object is not an
+     * instance of SeoAwareInterface
+     */
+    public function testGetDebugMessageWithBadObject()
+    {
+        $document = new \stdClass();
+        $routeProvider = $this->getMock('Symfony\Cmf\Component\Routing\RouteProviderInterface');
+        $urlGenerator = new DocumentUrlGenerator($routeProvider);
+        $debugMessage = $urlGenerator->getRouteDebugMessage($document);
+
+        $this->assertEquals(
+            'Given route object must be an instance of SeoAwareInterface',
+            $debugMessage
+        );
+    }
+
+    /**
+     * Tests exceptions in generate method
+     *
+     * @expectedException \Symfony\Component\Routing\Exception\RouteNotFoundException
+     */
+    public function testGenerateException()
+    {
+        $document = new \stdClass();
+        $routeProvider = $this->getMock('Symfony\Cmf\Component\Routing\RouteProviderInterface');
+        $urlGenerator = new DocumentUrlGenerator($routeProvider);
+
+        $urlGenerator->generate($document);
+    }
+}


### PR DESCRIPTION
Also fixed up getRouteDebugMessage() in url generator. It used to break if you provide anything other than string or instance of seoAwareInterface to it